### PR TITLE
Switch branch for NCEPLIBS-post

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,7 @@
 [submodule "NCEPLIBS-post"]
 	path = NCEPLIBS-post
 	url = https://github.com/NOAA-EMC/EMC_post
-	branch = ufs_release_v1.0
+	branch = ufs_public_release
 [submodule "netcdf"]
 	path = netcdf
 	url = https://github.com/NOAA-EMC/netcdf-c


### PR DESCRIPTION
Following a code manager meeting today (Jan 10), it was decided to rename the EMC_post branch from ufs_release_v1.0 to ufs_public_release. This PR updates .gitmodules and the submodule pointer with these changes. The code in NCEPLIBS-post remains identical.