### PR TITLE
Rename release branch for EMC_post

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,7 @@
 [submodule "NCEPLIBS-post"]
 	path = NCEPLIBS-post
 	url = https://github.com/NOAA-EMC/EMC_post
-	branch = release/public-v4
+	branch = release/public-v8
 [submodule "UFS_UTILS"]
 	path = UFS_UTILS
 	url = https://github.com/NOAA-EMC/UFS_UTILS


### PR DESCRIPTION
Rename release branch for EMC_post from release/public-v4 to release/public-v8. No code changes, the hash is identical before and after the update. Can be merged immediately.