### PR TITLE
beta04 final tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,19 @@ if(DEFINED EXTERNAL_LIBS_DIR)
   endif()
 endif()
 
+# If NETCDF is not set in the NCEPLIBS-external cmake configuration file,
+# need to add environment variable NETCDF to CMAKE_PREFIX_PATH for PkgConfig
+if(NOT NETCDF)
+  if(NOT DEFINED ENV{NETCDF})
+    message(FATAL_ERROR "Environment variable NETCDF not set")
+  else()
+    list(APPEND CMAKE_PREFIX_PATH $ENV{NETCDF})
+  endif()
+  if(DEFINED ENV{NETCDF_FORTRAN})
+    list(APPEND CMAKE_PREFIX_PATH $ENV{NETCDF_FORTRAN})
+  endif()
+endif()
+
 # Configure RPATH for shared linking
 if(NOT STATIC_IS_DEFAULT)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)


### PR DESCRIPTION
`CMakeLists.txt`: final tweaks for beta04, find NetCDF PkgConfig from NETCDF and NETCDF_FORTRAN environment variables. Will merge now to create preliminary beta04 tag.

TODO: Merge all of @aerorahul's PRs and update the submodule pointers.

Tested on jet, hera, gaea, macos, cheyenne.