### PR TITLE
Emergency bugfix for ufs-v1.0.0: need to set NETCDF cmake variable if not obtained from NCEPLIBS-external

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,13 @@ endif()
 
 # If NETCDF is not set in the NCEPLIBS-external cmake configuration file,
 # need to add environment variable NETCDF to CMAKE_PREFIX_PATH for PkgConfig
+# and set cmake variable accordingly
 if(NOT NETCDF)
   if(NOT DEFINED ENV{NETCDF})
     message(FATAL_ERROR "Environment variable NETCDF not set")
   else()
     list(APPEND CMAKE_PREFIX_PATH $ENV{NETCDF})
+    set(NETCDF $ENV{NETCDF})
   endif()
   if(DEFINED ENV{NETCDF_FORTRAN})
     list(APPEND CMAKE_PREFIX_PATH $ENV{NETCDF_FORTRAN})


### PR DESCRIPTION
In order to set `NETCDF=...` correctly in the shell scripts, need to set the NETCDF cmake variable from the NETCDF environment variable (which has to be defined if NCEPLIBS-external doesn't build NetCDF). This has been tested on orion and stampede (systems affected by the bug) and macOS and hera (systems not affected by the bug).

Will merge immediately and recreate the tag.