### PR TITLE
release/public-v1 (post-release change): update branch name for EMC_post

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,7 +69,7 @@
 [submodule "NCEPLIBS-post"]
 	path = NCEPLIBS-post
 	url = https://github.com/NOAA-EMC/EMC_post
-	branch = release/public-v8
+	branch = release/public-v1
 [submodule "UFS_UTILS"]
 	path = UFS_UTILS
 	url = https://github.com/NOAA-EMC/UFS_UTILS


### PR DESCRIPTION
Update branch name for EMC_post from release/public-v8 to release/public-v1.

This doesn't have to go into the release tag and can be merged anytime.
