### PR TITLE
shorter (cleaner) name for deployed modulefile

### DIFF
--- a/deploy_modulefiles.sh.in
+++ b/deploy_modulefiles.sh.in
@@ -35,7 +35,7 @@ for libName in $(ls -1 $tmplModulefilesDir); do
   # Define source and destination modulefile name
   # Destination filename must be consistent with CMakeLists.txt
   srcModulefile=$tmplModulefilesDir/$libName/$libName.lua
-  dstModulefile=$modulesDestDir/$libName/$libName-$ver.lua
+  dstModulefile=$modulesDestDir/$libName/$ver.lua
 
   # Create destination directory for the modulefile and copy template to it
   mkdir -p $modulesDestDir/$libName

--- a/tmplModulefiles/bacio/bacio.lua
+++ b/tmplModulefiles/bacio/bacio.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("bacio_ROOT", base)
 setenv("bacio_VERSION", pkgVersion)

--- a/tmplModulefiles/crtm/crtm.lua
+++ b/tmplModulefiles/crtm/crtm.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("crtm_ROOT", base)
 setenv("crtm_VERSION", pkgVersion)

--- a/tmplModulefiles/g2/g2.lua
+++ b/tmplModulefiles/g2/g2.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("g2_ROOT", base)
 setenv("g2_VERSION", pkgVersion)

--- a/tmplModulefiles/g2tmpl/g2tmpl.lua
+++ b/tmplModulefiles/g2tmpl/g2tmpl.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("g2tmpl_ROOT", base)
 setenv("g2tmpl_VERSION", pkgVersion)

--- a/tmplModulefiles/gfsio/gfsio.lua
+++ b/tmplModulefiles/gfsio/gfsio.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("gfsio_ROOT", base)
 setenv("gfsio_VERSION", pkgVersion)

--- a/tmplModulefiles/ip/ip.lua
+++ b/tmplModulefiles/ip/ip.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("ip_ROOT", base)
 setenv("ip_VERSION", pkgVersion)

--- a/tmplModulefiles/landsfcutil/landsfcutil.lua
+++ b/tmplModulefiles/landsfcutil/landsfcutil.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("landsfcutil_ROOT", base)
 setenv("landsfcutil_VERSION", pkgVersion)

--- a/tmplModulefiles/nceppost/nceppost.lua
+++ b/tmplModulefiles/nceppost/nceppost.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("nceppost_ROOT", base)
 setenv("nceppost_VERSION", pkgVersion)

--- a/tmplModulefiles/nemsio/nemsio.lua
+++ b/tmplModulefiles/nemsio/nemsio.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("nemsio_ROOT", base)
 setenv("nemsio_VERSION", pkgVersion)

--- a/tmplModulefiles/nemsiogfs/nemsiogfs.lua
+++ b/tmplModulefiles/nemsiogfs/nemsiogfs.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("nemsiogfs_ROOT", base)
 setenv("nemsiogfs_VERSION", pkgVersion)

--- a/tmplModulefiles/sfcio/sfcio.lua
+++ b/tmplModulefiles/sfcio/sfcio.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("sfcio_ROOT", base)
 setenv("sfcio_VERSION", pkgVersion)

--- a/tmplModulefiles/sigio/sigio.lua
+++ b/tmplModulefiles/sigio/sigio.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("sigio_ROOT", base)
 setenv("sigio_VERSION", pkgVersion)

--- a/tmplModulefiles/sp/sp.lua
+++ b/tmplModulefiles/sp/sp.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("sp_ROOT", base)
 setenv("sp_VERSION", pkgVersion)

--- a/tmplModulefiles/w3emc/w3emc.lua
+++ b/tmplModulefiles/w3emc/w3emc.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("w3emc_ROOT", base)
 setenv("w3emc_VERSION", pkgVersion)

--- a/tmplModulefiles/w3nco/w3nco.lua
+++ b/tmplModulefiles/w3nco/w3nco.lua
@@ -7,7 +7,7 @@ local pkgVersion = myModuleVersion()
 conflict(pkgName)
 
 local prefix = "#NCEPLIBS_ROOT#"
-local base = pathJoin(prefix,pkgName,pkgVersion)
+local base = pathJoin(prefix,pkgName,pkgName .. '-' .. pkgVersion)
 
 setenv("w3nco_ROOT", base)
 setenv("w3nco_VERSION", pkgVersion)


### PR DESCRIPTION
Suggestion from @DusanJovic-NOAA: 
instead of naming modulefiles `<package>-<version>.lua` name them `<version>.lua`

Change-Id: I1d473ab401abc1e5784675131bdcc3e8310c5448