### PR TITLE
Tagged versions of the updated CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ foreach(lib ${nceplibs})
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
                    "-DENABLE_TESTS=${ENABLE_TESTS}"
+		   "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+		   "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
     DEPENDS        ${${lib}_depends}
     )
 endforeach()
@@ -148,6 +150,8 @@ if(BUILD_CRTM)
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
+		   "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+		   "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
     )
 endif()
 
@@ -165,6 +169,8 @@ if(BUILD_POST)
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
                    "-DOPENMP=${OPENMP}"
                    "-DBUILD_POSTEXEC=OFF"
+		   "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+		   "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
     DEPENDS        bacio w3nco w3emc g2 g2tmpl ip sp crtm
     )
 endif()

--- a/COMPONENTS
+++ b/COMPONENTS
@@ -15,5 +15,5 @@ landsfcutil | v2.4.0            | v2.4.0
 g2          | v3.4.0            | v3.4.0
 g2tmpl      | v1.9.0            | v1.9.0
 crtm        | v2.3.0            | v2.3.0
-nceppost    | develop            | develop
+nceppost    | dceca26           | dceca26
 --------------------------------------------------------

--- a/COMPONENTS
+++ b/COMPONENTS
@@ -1,19 +1,19 @@
 --------------------------------------------------------
 COMPONENT   | BRANCH / TAG       | VERSION
 --------------------------------------------------------
-bacio       | develop            | develop
-sigio       | develop            | develop
-sfcio       | develop            | develop
-gfsio       | develop            | develop
-nemsio      | develop            | develop
-nemsiogfs   | develop            | develop
-w3emc       | develop            | develop
-w3nco       | develop            | develop
-ip          | develop            | develop
-sp          | develop            | develop
-landsfcutil | develop            | develop
-g2          | develop            | develop
-g2tmpl      | develop            | develop
-crtm        | develop            | develop
+bacio       | v2.4.0            | v2.4.0
+sigio       | v2.3.0            | v2.3.0
+sfcio       | v1.4.0            | v1.4.0
+gfsio       | v1.4.0            | v1.4.0
+nemsio      | v2.5.1            | v2.5.1
+nemsiogfs   | v2.5.0            | v2.5.0
+w3emc       | v2.7.0            | v2.7.0
+w3nco       | v2.4.0            | v2.4.0
+ip          | v3.3.0            | v3.3.0
+sp          | v2.3.0            | v2.3.0
+landsfcutil | v2.4.0            | v2.4.0
+g2          | v3.4.0            | v3.4.0
+g2tmpl      | v1.9.0            | v1.9.0
+crtm        | v2.3.0            | v2.3.0
 nceppost    | develop            | develop
 --------------------------------------------------------


### PR DESCRIPTION
Left Post as develop. Should that be changed?