### PR TITLE
Remove "v" from module file name.

### DIFF
--- a/COMPONENTS
+++ b/COMPONENTS
@@ -1,20 +1,20 @@
 --------------------------------------------------------
-COMPONENT   | BRANCH / TAG       | VERSION
+COMPONENT   | GIT BRANCH/TAG    | INSTALL AS
 --------------------------------------------------------
-bacio       | v2.4.0            | v2.4.0
-sigio       | v2.3.0            | v2.3.0
-sfcio       | v1.4.0            | v1.4.0
-gfsio       | v1.4.0            | v1.4.0
-nemsio      | v2.5.1            | v2.5.1
-nemsiogfs   | v2.5.0            | v2.5.0
-w3emc       | v2.7.0            | v2.7.0
-w3nco       | v2.4.0            | v2.4.0
-ip          | v3.3.0            | v3.3.0
-sp          | v2.3.0            | v2.3.0
-landsfcutil | v2.4.0            | v2.4.0
-g2          | v3.4.0            | v3.4.0
-g2tmpl      | v1.9.0            | v1.9.0
-crtm        | v2.3.0            | v2.3.0
+bacio       | v2.4.0            | 2.4.0
+sigio       | v2.3.0            | 2.3.0
+sfcio       | v1.4.0            | 1.4.0
+gfsio       | v1.4.0            | 1.4.0
+nemsio      | v2.5.1            | 2.5.1
+nemsiogfs   | v2.5.0            | 2.5.0
+w3emc       | v2.7.0            | 2.7.0
+w3nco       | v2.4.0            | 2.4.0
+ip          | v3.3.0            | 3.3.0
+sp          | v2.3.0            | 2.3.0
+landsfcutil | v2.4.0            | 2.4.0
+g2          | v3.4.0            | 3.4.0
+g2tmpl      | v1.9.0            | 1.9.0
+crtm        | v2.3.0            | 2.3.0
 nceppost    | dceca26           | dceca26
-wrf_io      | v1.1.1-cmake      | v1.1.1
+wrf_io      | v1.1.1-cmake      | 1.1.1
 --------------------------------------------------------


### PR DESCRIPTION
This PR 
- removes `v` from the modulefile name e.g. `v2.4.1.lua` -> `2.4.1.lua`. This more accurately follows semantic versioning and the version number in `CMakeLists.txt`.
 - Since module files are automatically generated and rely on `Lmod` functions to determine package name and version, 
 `v` was also removed from the installation prefix path of the package name. e.g. `bacio-vX.Y.Z` -> `bacio-X.Y.Z`. This also follows semantic versioning guidelines.

The previous iteration of package path was to continue existing convention with hand built libraries and modulefiles.

Change-Id: Ie0c21f9f267ae22a6f18155259b2c344208d5cc7