### PR TITLE
Update g2.lua

### DIFF
--- a/tmplModulefiles/g2/g2.lua
+++ b/tmplModulefiles/g2/g2.lua
@@ -11,7 +11,7 @@ local base = pathJoin(prefix,pkgName .. '-' .. pkgVersion)
 
 setenv("g2_ROOT", base)
 setenv("g2_VERSION", pkgVersion)
-setenv("g2_INC4", pathJoin(base,"include_4"))
+setenv("G2_INC4", pathJoin(base,"include_4"))
 setenv("G2_INCd", pathJoin(base,"include_d"))
 setenv("G2_LIB4", pathJoin(base,"lib/libg2_4.a"))
 setenv("G2_LIBd", pathJoin(base,"lib/libg2_d.a"))


### PR DESCRIPTION
This is a bugfix to provide correct environment variable for G2 include paths.