### PR TITLE
Add simple Python script to convert NCEPLIBS lua modulefiles into tcl modulefiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,10 +191,8 @@ if(DEPLOY)
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/deploy_modulefiles.sh)
   add_dependencies(deploy prep2deploy)
   if(TCLMOD)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lua2tcl.py
-                   ${CMAKE_CURRENT_BINARY_DIR}/lua2tcl.py COPYONLY)
     add_custom_target(tcl
-      COMMAND ${CMAKE_CURRENT_BINARY_DIR}/lua2tcl.py ${CMAKE_INSTALL_PREFIX}/modules)
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/lua2tcl.py ${CMAKE_INSTALL_PREFIX}/modules)
     add_dependencies(tcl deploy)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(ENABLE_TESTS "Enable testing"          OFF)
 option(BUILD_CRTM   "Build CRTM library"      ON)
 option(BUILD_POST   "Build NCEPpost library"  ON)
 option(DEPLOY       "Deploy modulefiles"      OFF)
+option(TCLMOD       "Create Tcl modulefiles " OFF)
 option(FLAT         "Flat install structure"  ON)
 option(LIBCOMPS     "File to read components from" ${DEFAULT_LIBCOMPS})
 
@@ -189,4 +190,11 @@ if(DEPLOY)
   add_custom_target(deploy
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/deploy_modulefiles.sh)
   add_dependencies(deploy prep2deploy)
+  if(TCLMOD)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lua2tcl.py
+                   ${CMAKE_CURRENT_BINARY_DIR}/lua2tcl.py COPYONLY)
+    add_custom_target(tcl
+      COMMAND ${CMAKE_CURRENT_BINARY_DIR}/lua2tcl.py ${CMAKE_INSTALL_PREFIX}/modules)
+    add_dependencies(tcl deploy)
+  endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ make deploy
 ```
 [LMod](https://lmod.readthedocs.io/en/latest/) Environment module system is required to load/unload these modules.
 
+Some HPC systems use Tcl based Environment modules.  NCEPLIBS provides a means to deploy Tcl module files and can be exercised as follows:
+
+`-DTCLMOD=ON` - enables option to change Lua modulefiles to Tcl modulefiles for each of the NCEPLIBS libraries.  To make the change:
+```
+make tcl
+```
+
 ### Usage
 
 `NCEPLIBS` can be used in any application that uses `cmake` to configure and build by adding `-DCMAKE_PREFIX_PATH=<nceplibs-prefix>` to the cmake command line during configuration.

--- a/lua2tcl.py
+++ b/lua2tcl.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import os
+import re
+import sys
+
+"""
+This script converts the NCEPLIBS lua modules into tcl modules for dinosaur systems
+that do not know how to handle lua modules in the 21st century. This script is not
+a general tool to convert lua modulefiles to tcl modules. It only works for the
+auto-generated lua modulefiles of the NCEPLIBS umbrella build.
+"""
+
+basedir=sys.argv[1]
+
+TCL_TEMPLATE="""#%Module######################################################################
+
+proc ModulesHelp {{ }} {{
+  puts "Set environment variables for {name}-{version}"
+}}
+
+# Make sure another version of the same package is not already loaded
+conflict {name}
+
+# Set environment variables
+set base {base}
+
+setenv {name}_ROOT    "${{base}}"
+setenv {name}_VERSION "{version}"
+{setenv_commands}
+"""
+
+for root,dirs,files in os.walk(basedir):
+    for file in files:
+        if file.endswith(".lua"):
+            version = file.rstrip(".lua")
+            name = os.path.split(root)[1]
+            infile = os.path.join(root,file)
+            outfile = os.path.join(root,file.rstrip(".lua"))
+            print("Converting {} to {} ...".format(infile, outfile))
+            with open(infile) as f:
+                lua_in = f.readlines()
+            prefix = None
+            base = None
+            setenv_commands = ''
+            for line_in in lua_in:
+                line = line_in.rstrip('\n')
+                if line.startswith("local prefix = \""):
+                    prefix = line.lstrip("local prefix = \"").rstrip("\"")
+                    base = os.path.join(prefix,"{name}-{version}".format(name=name, version=version))
+                elif line.startswith("setenv"):
+                    if line == 'setenv("{name}_ROOT", base)'.format(name=name):
+                        continue
+                    elif line == 'setenv("{name}_VERSION", pkgVersion)'.format(name=name):
+                        continue
+                    else:
+                        # Match lines like the following
+                        # setenv("BACIO_LIB8", pathJoin(base,"lib/libbacio_8.a"))
+                        match = re.match('^setenv\("(\w+)",\s+pathJoin\(base,"(.+)"\)\)$', line)
+                        if not match:
+                            raise Exception("Error while parsing line '{}' in {}".format(line, infile))
+                        envvar = match.group(1)
+                        value  = match.group(2)
+                        path = '${base}' + '/' + value
+                        setenv_commands += 'setenv {envvar} "{path}"\n'.format(envvar=envvar, path=path)
+                        continue
+            tcl_out = TCL_TEMPLATE.format(name=name, version=version, base=base, setenv_commands=setenv_commands)
+            if os.path.isfile(outfile):
+                os.remove(outfile)
+            with open(outfile, "w") as f:
+                f.write(tcl_out)


### PR DESCRIPTION
As the title says. Not a generic converter, but no more or no less than what is required the NCEPLIBS lua modulefiles for dinosaur systems.
