### PR TITLE
Propagate OpenMP flag to libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ foreach(lib ${nceplibs})
                    "-DENABLE_TESTS=${ENABLE_TESTS}"
                    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                    "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
+                   "-DOPENMP=${OPENMP}"
     DEPENDS        ${${lib}_depends}
     )
 endforeach()


### PR DESCRIPTION
Libraries don't build with OpenMP even if it's set to on.