### PR TITLE
enable a DOWNLOAD_ONLY option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build*/
 install*/
 modules*/
 test*/
+download*/
 
 *.[ao]
 *.mod

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,11 @@ modules*/
 test*/
 download*/
 
-*.[ao]
+*.[aox]
 *.mod
 *.swp
 *.exe
-*.x
+*.tgz
+*.tar*
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ install*/
 modules*/
 test*/
 download*/
+nceplibs-*/
+emc_*/
 
 *.[aox]
 *.mod
@@ -10,5 +12,6 @@ download*/
 *.exe
 *.tgz
 *.tar*
+
 
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,20 @@ endif()
 set(DEFAULT_LIBCOMPS ${CMAKE_CURRENT_SOURCE_DIR}/COMPONENTS)
 
 # User options
-option(OPENMP       "Enable OpenMP threading" OFF)
-option(ENABLE_TESTS "Enable testing"          OFF)
-option(BUILD_CRTM   "Build CRTM library"      ON)
-option(BUILD_POST   "Build NCEPpost library"  ON)
-option(DEPLOY       "Deploy modulefiles"      OFF)
-option(TCLMOD       "Create Tcl modulefiles " OFF)
-option(FLAT         "Flat install structure"  ON)
-option(LIBCOMPS     "File to read components from" ${DEFAULT_LIBCOMPS})
+option(OPENMP        "Enable OpenMP threading" OFF)
+option(ENABLE_TESTS  "Enable testing"          OFF)
+option(BUILD_CRTM    "Build CRTM library"      ON)
+option(BUILD_POST    "Build NCEPpost library"  ON)
+option(DEPLOY        "Deploy modulefiles"      OFF)
+option(TCLMOD        "Create Tcl modulefiles " OFF)
+option(FLAT          "Flat install structure"  ON)
+option(LIBCOMPS      "File to read components from" ${DEFAULT_LIBCOMPS})
+option(DOWNLOAD_ONLY "Just download the components" OFF)
+option(USE_LOCAL     "Use locally downloaded components" OFF)
+
+if(DOWNLOAD_ONLY AND USE_LOCAL)
+  message(FATAL_ERROR "DOWNLOAD_ONLY AND USE_LOCAL CANNOT BOTH BE ON, ABORT!")
+endif()
 
 # Read list of components to install from:
 if(NOT LIBCOMPS)
@@ -99,7 +105,7 @@ endfunction()
 # Collect list of components to append to CMAKE_PREFIX_PATH
 list(APPEND _comps
   bacio sigio sfcio gfsio ip sp w3nco g2 g2tmpl nemsio nemsiogfs landsfcutil w3emc wrf_io bufr)
-  
+
 # ip and ip2 cannot coexist in a flat structure because they share module names which overwrite each other
 if(NOT FLAT)
   list(APPEND _comps ip2)
@@ -128,14 +134,34 @@ set(nemsiogfs_depends nemsio)
 set(w3emc_depends nemsio sigio)
 set(ip2_depends sp)
 
+if(DOWNLOAD_ONLY)
+  set(CONFIGURE_ONLY "echo")
+  set(BUILD_ONLY     "echo")
+  set(INSTALL_ONLY   "echo")
+endif()
+
 foreach(lib ${nceplibs})
-  getTagVer("${LIBCOMPS_FILE}" "${lib}" tag ver)
+  getTagVer("${LIBCOMPS_FILE}" "${lib}" GIT_TAG ver)
   getInstallDir(${FLAT} ${lib} ${ver} installDir)
+  set(GIT_URL "https://github.com/noaa-emc/nceplibs-${lib}")
+
+  if(USE_LOCAL)
+    set(GIT_URL      "")
+    set(GIT_TAG      "")
+    set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/nceplibs-${lib}")
+  endif()
+
+  if(DOWNLOAD_ONLY)
+    set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/nceplibs-${lib}")
+    set(SOURCE_DIR   "${DOWNLOAD_DIR}")
+  endif()
 
   ExternalProject_Add(${lib}
-    GIT_REPOSITORY "https://github.com/noaa-emc/nceplibs-${lib}"
-    GIT_TAG        "${tag}"
+    GIT_REPOSITORY "${GIT_URL}"
+    GIT_TAG        "${GIT_TAG}"
     PREFIX         "${CMAKE_BINARY_DIR}/${lib}"
+    DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
+    SOURCE_DIR     "${SOURCE_DIR}"
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
@@ -144,8 +170,13 @@ foreach(lib ${nceplibs})
                    "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
                    "-DOPENMP=${OPENMP}"
     DEPENDS        ${${lib}_depends}
+    CONFIGURE_COMMAND ${CONFIGURE_ONLY}
+    BUILD_COMMAND     ${BUILD_ONLY}
+    INSTALL_COMMAND   ${INSTALL_ONLY}
     )
 endforeach()
+
+return()
 
 if(NOT FLAT)
   set(USE_IPOLATES 3)
@@ -157,13 +188,28 @@ else()
   set(wgrib2_depends "")
 endif()
 
-getTagVer("${LIBCOMPS_FILE}" "wgrib2" tag ver)
+getTagVer("${LIBCOMPS_FILE}" "wgrib2" GIT_TAG ver)
 getInstallDir(${FLAT} wgrib2 ${ver} installDir)
+set(GIT_URL "https://github.com/noaa-emc/nceplibs-wgrib2")
+
+if(USE_LOCAL)
+  set(GIT_URL      "")
+  set(GIT_TAG      "")
+  set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/nceplibs-wgrib2")
+endif()
+
+if(DOWNLOAD_ONLY)
+  set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/nceplibs-wgrib2")
+  set(SOURCE_DIR   "${DOWNLOAD_DIR}")
+endif()
+
 ExternalProject_Add(wgrib2
-  GIT_REPOSITORY "https://github.com/noaa-emc/nceplibs-wgrib2"
-  GIT_TAG "${tag}"
-  PREFIX "${CMAKE_BINARY_DIR}/wgrib2"
-  LIST_SEPARATOR | 
+  GIT_REPOSITORY "${GIT_URL}"
+  GIT_TAG        "${GIT_TAG}"
+  PREFIX         "${CMAKE_BINARY_DIR}/wgrib2"
+  DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
+  SOURCE_DIR     "${SOURCE_DIR}"
+  LIST_SEPARATOR |
   CMAKE_ARGS "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
              "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
              "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
@@ -172,34 +218,68 @@ ExternalProject_Add(wgrib2
              "-DUSE_IPOLATES=${USE_IPOLATES}"
              "-DUSE_SPECTRAL=${USE_SPECTRAL}"
   DEPENDS    ${wgrib2_depends}
+  CONFIGURE_COMMAND ${CONFIGURE_ONLY}
+  BUILD_COMMAND     ${BUILD_ONLY}
+  INSTALL_COMMAND   ${INSTALL_ONLY}
   )
-        
+
 
 if(BUILD_CRTM)
-  getTagVer("${LIBCOMPS_FILE}" "crtm" tag ver)
+  getTagVer("${LIBCOMPS_FILE}" "crtm" GIT_TAG ver)
   getInstallDir(${FLAT} "crtm" ${ver} installDir)
+  set(GIT_URL "https://github.com/noaa-emc/emc_crtm")
+
+  if(USE_LOCAL)
+    set(GIT_URL      "")
+    set(GIT_TAG      "")
+    set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/emc_crtm")
+  endif()
+
+  if(DOWNLOAD_ONLY)
+    set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/emc_crtm")
+    set(SOURCE_DIR   "${DOWNLOAD_DIR}")
+  endif()
 
   ExternalProject_Add(crtm
-    GIT_REPOSITORY "https://github.com/noaa-emc/emc_crtm"
-    GIT_TAG        "${tag}"
+    GIT_REPOSITORY "${GIT_URL}"
+    GIT_TAG        "${GIT_TAG}"
     PREFIX         "${CMAKE_BINARY_DIR}/crtm"
+    DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
+    SOURCE_DIR     "${SOURCE_DIR}"
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
                    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                    "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
+    CONFIGURE_COMMAND ${CONFIGURE_ONLY}
+    BUILD_COMMAND     ${BUILD_ONLY}
+    INSTALL_COMMAND   ${INSTALL_ONLY}
     )
 endif()
 
 if(BUILD_POST)
-  getTagVer("${LIBCOMPS_FILE}" "nceppost" tag ver)
+  getTagVer("${LIBCOMPS_FILE}" "nceppost" GIT_TAG ver)
   getInstallDir(${FLAT} "nceppost" ${ver} installDir)
+  set(GIT_URL "https://github.com/noaa-emc/emc_post")
+
+  if(USE_LOCAL)
+    set(GIT_URL      "")
+    set(GIT_TAG      "")
+    set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/emc_post")
+  endif()
+
+  if(DOWNLOAD_ONLY)
+    set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/emc_post")
+    set(SOURCE_DIR   "${DOWNLOAD_DIR}")
+  endif()
 
   ExternalProject_Add(nceppost
-    GIT_REPOSITORY "https://github.com/noaa-emc/emc_post"
-    GIT_TAG        "${tag}"
+    GIT_REPOSITORY "${GIT_URL}"
+    GIT_TAG        "${GIT_TAG}"
     GIT_SUBMODULES "CMakeModules"
     PREFIX         "${CMAKE_BINARY_DIR}/nceppost"
+    DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
+    SOURCE_DIR     "${SOURCE_DIR}"
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
@@ -208,6 +288,9 @@ if(BUILD_POST)
                    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                    "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
     DEPENDS        bacio w3nco w3emc g2 g2tmpl ip sp crtm
+    CONFIGURE_COMMAND ${CONFIGURE_ONLY}
+    BUILD_COMMAND     ${BUILD_ONLY}
+    INSTALL_COMMAND   ${INSTALL_ONLY}
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,25 +161,20 @@ endif()
 foreach(lib ${nceplibs})
   getTagVer("${LIBCOMPS_FILE}" "${lib}" GIT_TAG ver)
   getInstallDir(${FLAT} ${lib} ${ver} installDir)
-  set(GIT_URL "https://github.com/noaa-emc/nceplibs-${lib}")
+
+  set(GIT_URL    "https://github.com/noaa-emc/nceplibs-${lib}")
+  set(SOURCE_DIR "${CMAKE_SOURCE_DIR}/download/nceplibs-${lib}")
 
   if(USE_LOCAL)
     set(GIT_URL      "")
     set(GIT_TAG      "")
-    set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/nceplibs-${lib}")
     trapLocalError(${SOURCE_DIR})
-  endif()
-
-  if(DOWNLOAD_ONLY)
-    set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/nceplibs-${lib}")
-    set(SOURCE_DIR   "${DOWNLOAD_DIR}")
   endif()
 
   ExternalProject_Add(${lib}
     GIT_REPOSITORY "${GIT_URL}"
     GIT_TAG        "${GIT_TAG}"
     PREFIX         "${CMAKE_BINARY_DIR}/${lib}"
-    DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
     SOURCE_DIR     "${SOURCE_DIR}"
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
@@ -199,25 +194,20 @@ endforeach()
 if(BUILD_CRTM)
   getTagVer("${LIBCOMPS_FILE}" "crtm" GIT_TAG ver)
   getInstallDir(${FLAT} "crtm" ${ver} installDir)
-  set(GIT_URL "https://github.com/noaa-emc/emc_crtm")
+
+  set(GIT_URL    "https://github.com/noaa-emc/emc_crtm")
+  set(SOURCE_DIR "${CMAKE_SOURCE_DIR}/download/emc_crtm")
 
   if(USE_LOCAL)
     set(GIT_URL      "")
     set(GIT_TAG      "")
-    set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/emc_crtm")
     trapLocalError(${SOURCE_DIR})
-  endif()
-
-  if(DOWNLOAD_ONLY)
-    set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/emc_crtm")
-    set(SOURCE_DIR   "${DOWNLOAD_DIR}")
   endif()
 
   ExternalProject_Add(crtm
     GIT_REPOSITORY "${GIT_URL}"
     GIT_TAG        "${GIT_TAG}"
     PREFIX         "${CMAKE_BINARY_DIR}/crtm"
-    DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
     SOURCE_DIR     "${SOURCE_DIR}"
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
@@ -233,18 +223,14 @@ endif()
 if(BUILD_POST)
   getTagVer("${LIBCOMPS_FILE}" "nceppost" GIT_TAG ver)
   getInstallDir(${FLAT} "nceppost" ${ver} installDir)
-  set(GIT_URL "https://github.com/noaa-emc/emc_post")
+
+  set(GIT_URL    "https://github.com/noaa-emc/emc_post")
+  set(SOURCE_DIR "${CMAKE_SOURCE_DIR}/download/emc_post")
 
   if(USE_LOCAL)
     set(GIT_URL      "")
     set(GIT_TAG      "")
-    set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/emc_post")
     trapLocalError(${SOURCE_DIR})
-  endif()
-
-  if(DOWNLOAD_ONLY)
-    set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/emc_post")
-    set(SOURCE_DIR   "${DOWNLOAD_DIR}")
   endif()
 
   ExternalProject_Add(nceppost
@@ -252,7 +238,6 @@ if(BUILD_POST)
     GIT_TAG        "${GIT_TAG}"
     GIT_SUBMODULES "CMakeModules"
     PREFIX         "${CMAKE_BINARY_DIR}/nceppost"
-    DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
     SOURCE_DIR     "${SOURCE_DIR}"
     LIST_SEPARATOR |
     CMAKE_ARGS     "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ if(DOWNLOAD_ONLY)
   add_custom_target(tarball
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMAND tar -czf nceplibs.tgz download)
+    add_dependencies(tarball ${_comps})
 endif()
 
 # Prepare to deploy modulefiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ if(DEPLOY)
   endif()
 endif()
 
+function(trapLocalError sourceDir)
+  if(NOT EXISTS ${sourceDir})
+    message(FATAL_ERROR "Directory does not exist ${sourceDir}, ABORT!")
+  endif()
+endfunction()
+
 function(getInstallDir FLAT lib ver installDir)
   if(FLAT)
     set(var ${lib}-${ver})
@@ -104,7 +110,7 @@ endfunction()
 
 # Collect list of components to append to CMAKE_PREFIX_PATH
 list(APPEND _comps
-  bacio sigio sfcio gfsio ip sp w3nco g2 g2tmpl nemsio nemsiogfs landsfcutil w3emc wrf_io bufr)
+  bacio sigio sfcio gfsio ip sp w3nco g2 g2tmpl nemsio nemsiogfs landsfcutil w3emc wrf_io bufr wgrib2)
 
 # ip and ip2 cannot coexist in a flat structure because they share module names which overwrite each other
 if(NOT FLAT)
@@ -134,6 +140,18 @@ set(nemsiogfs_depends nemsio)
 set(w3emc_depends nemsio sigio)
 set(ip2_depends sp)
 
+if(NOT FLAT)
+  set(USE_IPOLATES 3)
+  set(USE_SPECTRAL ON)
+  set(wgrib2_depends ip2 sp)
+else()
+  set(USE_IPOLATES 0)
+  set(USE_SPECTRAL OFF)
+  set(wgrib2_depends "")
+endif()
+list(APPEND wgrib2_CMAKE_ARGS -DUSE_IPOLATES=${USE_IPOLATES}
+                              -DUSE_SPECTRAL=${USE_SPECTRAL})
+
 if(DOWNLOAD_ONLY)
   set(CONFIGURE_ONLY "echo")
   set(BUILD_ONLY     "echo")
@@ -149,6 +167,7 @@ foreach(lib ${nceplibs})
     set(GIT_URL      "")
     set(GIT_TAG      "")
     set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/nceplibs-${lib}")
+    trapLocalError(${SOURCE_DIR})
   endif()
 
   if(DOWNLOAD_ONLY)
@@ -169,58 +188,13 @@ foreach(lib ${nceplibs})
                    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                    "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
                    "-DOPENMP=${OPENMP}"
+                   ${${lib}_CMAKE_ARGS}
     DEPENDS        ${${lib}_depends}
     CONFIGURE_COMMAND ${CONFIGURE_ONLY}
     BUILD_COMMAND     ${BUILD_ONLY}
     INSTALL_COMMAND   ${INSTALL_ONLY}
     )
 endforeach()
-
-if(NOT FLAT)
-  set(USE_IPOLATES 3)
-  set(USE_SPECTRAL ON)
-  set(wgrib2_depends ip2 sp)
-else()
-  set(USE_IPOLATES 0)
-  set(USE_SPECTRAL OFF)
-  set(wgrib2_depends "")
-endif()
-
-getTagVer("${LIBCOMPS_FILE}" "wgrib2" GIT_TAG ver)
-getInstallDir(${FLAT} wgrib2 ${ver} installDir)
-set(GIT_URL "https://github.com/noaa-emc/nceplibs-wgrib2")
-
-if(USE_LOCAL)
-  set(GIT_URL      "")
-  set(GIT_TAG      "")
-  set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/nceplibs-wgrib2")
-endif()
-
-if(DOWNLOAD_ONLY)
-  set(DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/download/nceplibs-wgrib2")
-  set(SOURCE_DIR   "${DOWNLOAD_DIR}")
-endif()
-
-ExternalProject_Add(wgrib2
-  GIT_REPOSITORY "${GIT_URL}"
-  GIT_TAG        "${GIT_TAG}"
-  PREFIX         "${CMAKE_BINARY_DIR}/wgrib2"
-  DOWNLOAD_DIR   "${DOWNLOAD_DIR}"
-  SOURCE_DIR     "${SOURCE_DIR}"
-  LIST_SEPARATOR |
-  CMAKE_ARGS "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_ALT_SEP}"
-             "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${installDir}"
-             "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
-             "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
-             "-DOPENMP=${OPENMP}"
-             "-DUSE_IPOLATES=${USE_IPOLATES}"
-             "-DUSE_SPECTRAL=${USE_SPECTRAL}"
-  DEPENDS    ${wgrib2_depends}
-  CONFIGURE_COMMAND ${CONFIGURE_ONLY}
-  BUILD_COMMAND     ${BUILD_ONLY}
-  INSTALL_COMMAND   ${INSTALL_ONLY}
-  )
-
 
 if(BUILD_CRTM)
   getTagVer("${LIBCOMPS_FILE}" "crtm" GIT_TAG ver)
@@ -231,6 +205,7 @@ if(BUILD_CRTM)
     set(GIT_URL      "")
     set(GIT_TAG      "")
     set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/emc_crtm")
+    trapLocalError(${SOURCE_DIR})
   endif()
 
   if(DOWNLOAD_ONLY)
@@ -264,6 +239,7 @@ if(BUILD_POST)
     set(GIT_URL      "")
     set(GIT_TAG      "")
     set(SOURCE_DIR   "${CMAKE_SOURCE_DIR}/download/emc_post")
+    trapLocalError(${SOURCE_DIR})
   endif()
 
   if(DOWNLOAD_ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,6 @@ foreach(lib ${nceplibs})
     )
 endforeach()
 
-return()
-
 if(NOT FLAT)
   set(USE_IPOLATES 3)
   set(USE_SPECTRAL ON)
@@ -292,6 +290,12 @@ if(BUILD_POST)
     BUILD_COMMAND     ${BUILD_ONLY}
     INSTALL_COMMAND   ${INSTALL_ONLY}
     )
+endif()
+
+if(DOWNLOAD_ONLY)
+  add_custom_target(tarball
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMAND tar -czf nceplibs.tgz download)
 endif()
 
 # Prepare to deploy modulefiles

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Some HPC systems use Tcl based Environment modules.  NCEPLIBS provides a means t
 make tcl
 ```
 
+On machines that do not provide access to Github, a `DOWNLOAD_ONLY` and `USE_LOCAL` option is provided.  To download the NCEPLIBS without building them use the cmake command line option `-DDOWNLOAD_ONLY=ON`.  This will download all the NCEPLIBS in a local `download` folder.  `make tarball` will tar and zip this folder into `nceplibs.tgz` which can then be transferred to the machine without GitHub access.  Untar the tarball, and use the cmake command line option `USE_LOCAL` as `-DUSE_LOCAL=ON`.  This will use the source code from the download directory.
+
 ### Usage
 
 `NCEPLIBS` can be used in any application that uses `cmake` to configure and build by adding `-DCMAKE_PREFIX_PATH=<nceplibs-prefix>` to the cmake command line during configuration.


### PR DESCRIPTION
`cmake -DDOWNLOAD_ONLY=ON`
will download everything to `./download`

`make tarball` will tar and zip `./download` into `nceplibs.tgz`
Transfer `nceplibs.tgz` to the the machine and untar in the umbrella directory.

`cmake -DUSE_LOCAL=ON`
will use the packages from ./download`

Give this a try.