### PR TITLE
release/public-v2: workaround for emc_post with gfortran-10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,12 @@ if(BUILD_POST)
     trapLocalError(${SOURCE_DIR})
   endif()
 
+  if(${CMAKE_Fortran_COMPILER_ID} MATCHES "^(GNU)$" AND ${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10)
+    set(EMC_POST_PATCH_COMMAND "${CMAKE_SOURCE_DIR}/emc_post_gfortran-10.sh")
+  else()
+    set(EMC_POST_PATCH_COMMAND "echo")
+  endif()
+
   ExternalProject_Add(nceppost
     GIT_REPOSITORY "${GIT_URL}"
     GIT_TAG        "${GIT_TAG}"
@@ -235,6 +241,7 @@ if(BUILD_POST)
                    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                    "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
     DEPENDS        bacio w3nco w3emc g2 g2tmpl ip sp crtm
+    PATCH_COMMAND     "${EMC_POST_PATCH_COMMAND}"
     CONFIGURE_COMMAND ${CONFIGURE_ONLY}
     BUILD_COMMAND     ${BUILD_ONLY}
     INSTALL_COMMAND   ${INSTALL_ONLY}

--- a/emc_post_gfortran-10.patch
+++ b/emc_post_gfortran-10.patch
@@ -1,0 +1,13 @@
+--- download/emc_post/sorc/ncep_post.fd/CMakeLists.txt	2020-09-17 13:04:57.000000000 -0600
++++ download/emc_post/sorc/ncep_post.fd/CMakeLists.txt	2020-09-17 13:05:53.000000000 -0600
+@@ -187,6 +187,10 @@
+   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check")
+ endif()
+ 
++if(${CMAKE_Fortran_COMPILER_ID} MATCHES "^(GNU)$" AND ${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10)
++  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -fallow-argument-mismatch") # " -fallow-invalid-boz")
++endif()
++
+ set(LIBNAME "nceppost")
+ set(EXENAME "nceppost.x")
+ 

--- a/emc_post_gfortran-10.sh
+++ b/emc_post_gfortran-10.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $MYDIR
+patch -p0 < emc_post_gfortran-10.patch 


### PR DESCRIPTION
Problem is described here: https://github.com/NOAA-EMC/EMC_post/issues/186

Proposed solution (more of a workaround): patch the emc_post dceca26 tag for gfortran-10.

Comments and improvements appreciated.