### PR TITLE
release/public-v1: update of UFS_UTILS to fix grib2 read errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,5 +72,7 @@
 	branch = release/public-v1
 [submodule "UFS_UTILS"]
 	path = UFS_UTILS
-	url = https://github.com/NOAA-EMC/UFS_UTILS
-	branch = release/public-v1
+	#url = https://github.com/NOAA-EMC/UFS_UTILS
+	#branch = release/public-v1
+	url = https://github.com/climbfuji/UFS_UTILS
+	branch = fix_grib2_errors_mrwapp

--- a/.gitmodules
+++ b/.gitmodules
@@ -72,7 +72,5 @@
 	branch = release/public-v1
 [submodule "UFS_UTILS"]
 	path = UFS_UTILS
-	#url = https://github.com/NOAA-EMC/UFS_UTILS
-	#branch = release/public-v1
-	url = https://github.com/climbfuji/UFS_UTILS
-	branch = fix_grib2_errors_mrwapp
+	url = https://github.com/NOAA-EMC/UFS_UTILS
+	branch = release/public-v1


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for UFS_UTILS for changes described in https://github.com/NOAA-EMC/UFS_UTILS/pull/155.

This bugfix will not change the answer.

## Testing

This has been tested on Cheyenne with Intel and GNU, and on Orion with Intel. Works as expected.