### PR TITLE
release/public-v1: update submodule pointer for EMC_post (bugfix for finding netCDF)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,8 +68,10 @@
 	branch = release/public-v1
 [submodule "NCEPLIBS-post"]
 	path = NCEPLIBS-post
-	url = https://github.com/NOAA-EMC/EMC_post
-	branch = release/public-v1
+	#url = https://github.com/NOAA-EMC/EMC_post
+	#branch = release/public-v1
+	url = https://github.com/climbfuji/EMC_post
+	branch = find_netcdf_bugfix_release_public_v1
 [submodule "UFS_UTILS"]
 	path = UFS_UTILS
 	url = https://github.com/NOAA-EMC/UFS_UTILS

--- a/.gitmodules
+++ b/.gitmodules
@@ -68,10 +68,8 @@
 	branch = release/public-v1
 [submodule "NCEPLIBS-post"]
 	path = NCEPLIBS-post
-	#url = https://github.com/NOAA-EMC/EMC_post
-	#branch = release/public-v1
-	url = https://github.com/climbfuji/EMC_post
-	branch = find_netcdf_bugfix_release_public_v1
+	url = https://github.com/NOAA-EMC/EMC_post
+	branch = release/public-v1
 [submodule "UFS_UTILS"]
 	path = UFS_UTILS
 	url = https://github.com/NOAA-EMC/UFS_UTILS


### PR DESCRIPTION
As the title says, see https://github.com/NOAA-EMC/EMC_post/pull/191 for a description.

Will need to retag ufs-v1.1.0 after this PR is merged.