### PR TITLE
release/public-v2: bugfix for recompiling

### DIFF
--- a/emc_post_gfortran-10.sh
+++ b/emc_post_gfortran-10.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-set -ex
+set -x
 
 MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $MYDIR
-patch -p0 < emc_post_gfortran-10.patch 
+patch -N -p0 < emc_post_gfortran-10.patch
+exit 0


### PR DESCRIPTION
When the NCEPLIBS `make` command is called more than once, it fails because `emc_post`'s patch command exits with a status other than zero (because the patch has been applied beforehand). This PR fixes it.